### PR TITLE
fix: bump puppeteer from 13.1.1 to 13.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "puppeteer": "^13.1.1"
+        "puppeteer": "^13.1.2"
       },
       "bin": {
         "scrape-text": "index.js"
@@ -1851,14 +1851,22 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-assign": {
@@ -2284,16 +2292,16 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.1.1.tgz",
-      "integrity": "sha512-GwdFy1JQ43Hhxj6MraXme+XfCX2CKe18MuwToXTMEAk0txg6vUEgwqBnzErTTqDVZ7sWYrDtDaRCfD2y7ZwgGw==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.1.2.tgz",
+      "integrity": "sha512-ozVM8Tdg0patMtm/xAr3Uh7rQ28vBpbTHLP+ECmoAxG/s4PKrVLN764H/poLux7Ln77jHThOd8OBJj5mTuA6Iw==",
       "hasInstallScript": true,
       "dependencies": {
         "debug": "4.3.2",
         "devtools-protocol": "0.0.948846",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.0",
-        "node-fetch": "2.6.5",
+        "node-fetch": "2.6.7",
         "pkg-dir": "4.2.0",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
@@ -4299,9 +4307,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -4619,15 +4627,15 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.1.1.tgz",
-      "integrity": "sha512-GwdFy1JQ43Hhxj6MraXme+XfCX2CKe18MuwToXTMEAk0txg6vUEgwqBnzErTTqDVZ7sWYrDtDaRCfD2y7ZwgGw==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.1.2.tgz",
+      "integrity": "sha512-ozVM8Tdg0patMtm/xAr3Uh7rQ28vBpbTHLP+ECmoAxG/s4PKrVLN764H/poLux7Ln77jHThOd8OBJj5mTuA6Iw==",
       "requires": {
         "debug": "4.3.2",
         "devtools-protocol": "0.0.948846",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.0",
-        "node-fetch": "2.6.5",
+        "node-fetch": "2.6.7",
         "pkg-dir": "4.2.0",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "semistandard": "^16.0.1"
   },
   "dependencies": {
-    "puppeteer": "^13.1.1"
+    "puppeteer": "^13.1.2"
   }
 }


### PR DESCRIPTION
The node-fetch transitive dependency is a security fix, so push a new
release for this.